### PR TITLE
fix(api-reference): render x-enumDescriptions for enum values in schema

### DIFF
--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -18,12 +18,17 @@
 
     <!-- Initialize the Scalar API Reference -->
     <script type="module">
+      // Load the local galaxy spec
+      const galaxySpec = await fetch(
+        '/node_modules/@scalar/galaxy/dist/latest.json',
+      ).then((r) => r.json())
+
       Scalar.createApiReference('#app', {
         sources: [
           {
             title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
             slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+            content: galaxySpec,
           },
           {
             title: 'Swagger Petstore 2.0',

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -316,7 +316,7 @@ const shouldShowEnumDescriptions = computed(() => {
       <template v-if="shouldShowEnumDescriptions">
         <div class="property-list">
           <div
-            v-for="enumValue in getEnumFromValue(optimizedValue)"
+            v-for="enumValue in visibleEnumValues"
             :key="enumValue"
             class="property">
             <div class="property-heading">
@@ -329,10 +329,42 @@ const shouldShowEnumDescriptions = computed(() => {
                 :value="optimizedValue?.['x-enumDescriptions']?.[enumValue]" />
             </div>
           </div>
+          <Disclosure
+            v-if="hasLongEnumList"
+            v-slot="{ open }">
+            <DisclosurePanel>
+              <div
+                v-for="enumValue in remainingEnumValues"
+                :key="enumValue"
+                class="property">
+                <div class="property-heading">
+                  <div class="property-name">
+                    {{ enumValue }}
+                  </div>
+                </div>
+                <div class="property-description">
+                  <ScalarMarkdown
+                    :value="
+                      optimizedValue?.['x-enumDescriptions']?.[enumValue]
+                    " />
+                </div>
+              </div>
+            </DisclosurePanel>
+            <DisclosureButton class="enum-toggle-button">
+              <ScalarIcon
+                class="enum-toggle-button-icon"
+                :class="{ 'enum-toggle-button-icon--open': open }"
+                icon="Add"
+                size="sm" />
+              {{ open ? 'Hide values' : 'Show all values' }}
+            </DisclosureButton>
+          </Disclosure>
         </div>
       </template>
       <template v-else>
-        <ul class="property-enum-values">
+        <ul
+          v-if="!optimizedValue?.['x-enumDescriptions']"
+          class="property-enum-values">
           <li
             v-for="enumValue in visibleEnumValues"
             :key="enumValue"
@@ -364,6 +396,56 @@ const shouldShowEnumDescriptions = computed(() => {
             </DisclosureButton>
           </Disclosure>
         </ul>
+        <div
+          v-else
+          class="property-list">
+          <div
+            v-for="enumValue in visibleEnumValues"
+            :key="enumValue"
+            class="property">
+            <div class="property-heading">
+              <div class="property-name">
+                {{ enumValue }}
+              </div>
+            </div>
+            <div
+              v-if="optimizedValue?.['x-enumDescriptions']?.[enumValue]"
+              class="property-description">
+              <ScalarMarkdown
+                :value="optimizedValue['x-enumDescriptions'][enumValue]" />
+            </div>
+          </div>
+          <Disclosure
+            v-if="hasLongEnumList"
+            v-slot="{ open }">
+            <DisclosurePanel>
+              <div
+                v-for="enumValue in remainingEnumValues"
+                :key="enumValue"
+                class="property">
+                <div class="property-heading">
+                  <div class="property-name">
+                    {{ enumValue }}
+                  </div>
+                </div>
+                <div
+                  v-if="optimizedValue?.['x-enumDescriptions']?.[enumValue]"
+                  class="property-description">
+                  <ScalarMarkdown
+                    :value="optimizedValue['x-enumDescriptions'][enumValue]" />
+                </div>
+              </div>
+            </DisclosurePanel>
+            <DisclosureButton class="enum-toggle-button">
+              <ScalarIcon
+                class="enum-toggle-button-icon"
+                :class="{ 'enum-toggle-button-icon--open': open }"
+                icon="Add"
+                size="sm" />
+              {{ open ? 'Hide values' : 'Show all values' }}
+            </DisclosureButton>
+          </Disclosure>
+        </div>
       </template>
     </div>
     <!-- Object -->

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -718,6 +718,12 @@ components:
             - ice_giant
             - dwarf
             - super_earth
+          x-enumDescriptions:
+            terrestrial: Rocky planets with solid surfaces like Earth and Mars
+            gas_giant: Large planets primarily composed of hydrogen and helium like Jupiter and Saturn
+            ice_giant: Planets with thick atmospheres of water, methane, and ammonia ice like Uranus and Neptune
+            dwarf: Planets that have not cleared their orbital path of other debris
+            super_earth: Rocky planets more massive than Earth but lighter than Neptune
           examples:
             - terrestrial
         habitabilityIndex:


### PR DESCRIPTION
**Problem**

   Currently, enum values with x-enumDescriptions are not always displayed correctly in the API reference schema
   viewer. The component relies on a shouldShowEnumDescriptions computed property that has edge cases where it
   returns false even when x-enumDescriptions exist in the spec. When this happens, the descriptions are ignored and
   users only see a plain bullet list of enum values without any explanatory text.

Solution

  With this PR, I've fixed the rendering issue by adding a defensive fallback in the SchemaProperty component:

  - Added a secondary check for x-enumDescriptions that catches cases where the primary computed property fails
  - Implemented pagination for long enum lists with a collapse/expand disclosure button
  - Split the rendering logic into three paths: (1) descriptions shown via primary check, (2) descriptions shown via
   fallback check, (3) simple list when no descriptions exist
  - Added example x-enumDescriptions to the Galaxy spec's planetType enum to demonstrate the feature
  - Modified index.html to load the local Galaxy spec instead of CDN for testing purposes (can revert if needed)

  This ensures enum descriptions are always displayed when present, and long lists remain manageable.


  Before:
<img width="921" height="797" alt="image" src="https://github.com/user-attachments/assets/8e568c05-94e3-499f-aef9-1e9419249ae0" />
  After:
  
<img width="1873" height="823" alt="image" src="https://github.com/user-attachments/assets/952cd2cf-bbe6-4230-9e82-c7c328034d3a" />

https://github.com/user-attachments/assets/ae46b673-8738-4887-bc9d-9ee69a4edf8a


  Note: The index.html change is for local testing/review purposes. Happy to revert it before merge if the
  maintainers prefer.
