### PR TITLE
fix: respect explicit darkMode: false configuration

### DIFF
--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -47,7 +47,12 @@ const configProxy = computed({
 })
 
 const { toggleColorMode, isDarkMode } = useColorMode({
-  initialColorMode: configuration.darkMode ? 'dark' : undefined,
+  initialColorMode:
+    configuration.darkMode !== undefined
+      ? configuration.darkMode
+        ? 'dark'
+        : 'light'
+      : undefined,
   overrideColorMode: configuration.forceDarkModeState,
 })
 
@@ -57,6 +62,7 @@ watch(
     document.body.classList.toggle('dark-mode', Boolean(isDark))
     document.body.classList.toggle('light-mode', !isDark)
   },
+  { immediate: true },
 )
 </script>
 <template>


### PR DESCRIPTION
**Problem**

Currently, the API Reference component does not respect the `darkMode: false` configuration. When explicitly set to `false`, the component ignores this setting and behaves as if no preference was set, potentially defaulting to dark mode or using system preferences. This prevents developers from forcing light mode initialization.

**Solution**

With this PR, the `initialColorMode` logic now properly distinguishes between `darkMode: false` and `undefined`:
  - `darkMode: true` → Force dark mode
  - `darkMode: false` → Force light mode
  - `darkMode: undefined` → Auto-detect from system preferences

Additionally, dark mode classes are now applied immediately on mount using the watcher's `immediate: true` option, ensuring the correct theme is applied from the start.
**Checklist**

**Before:**
<img width="1901" height="643" alt="image" src="https://github.com/user-attachments/assets/e53fceff-5b9d-4a22-ae72-80d6c8372bc0" />
**After:**
<img width="1904" height="703" alt="image" src="https://github.com/user-attachments/assets/a514a1a6-6145-48f4-8613-e2c7735a77c0" />

The solution can be inspected properly through the toggle on initialization as the component now checks on mount.

**Video Explanation:**

https://github.com/user-attachments/assets/dcd234ea-f920-420f-a131-441bea10ed7a


